### PR TITLE
fix: prevent duplicate CPF registration and add findByCpf method

### DIFF
--- a/src/core/errors/use-case-error.ts
+++ b/src/core/errors/use-case-error.ts
@@ -1,0 +1,3 @@
+export interface UseCaseError {
+  message: string
+}

--- a/src/domain/application/repositories/delivery-people.repository.ts
+++ b/src/domain/application/repositories/delivery-people.repository.ts
@@ -2,4 +2,5 @@ import { DeliveryPerson } from '@/domain/enterprise/entities/delivery-person'
 
 export abstract class DeliveryPeopleRepository {
   abstract create(deliveryPerson: DeliveryPerson): Promise<void>
+  abstract findByCpf(cpf: string): Promise<DeliveryPerson | null>
 }

--- a/src/domain/application/use-cases/errors/delivery-person-already-exists.error.ts
+++ b/src/domain/application/use-cases/errors/delivery-person-already-exists.error.ts
@@ -1,0 +1,10 @@
+import { UseCaseError } from '@/core/errors/use-case-error'
+
+export class DeliveryPersonAlreadyExistsError
+  extends Error
+  implements UseCaseError
+{
+  constructor() {
+    super('Delivery person already registered.')
+  }
+}

--- a/src/domain/application/use-cases/register-delivery-person.spec.ts
+++ b/src/domain/application/use-cases/register-delivery-person.spec.ts
@@ -18,7 +18,8 @@ describe('Register Delivery Person', () => {
       password: '123456',
     })
 
-    expect(result.isRight).toBeTruthy()
+    expect(result.isRight()).toBeTruthy()
+    if (result.isLeft()) throw new Error()
     expect(result.value?.deliveryPerson.id).toBeTruthy()
     expect(result.value?.deliveryPerson.isAdmin()).toBeFalsy()
     expect(deliveryPersonRepository.items[0]).toEqual(

--- a/src/domain/application/use-cases/register-delivery-person.ts
+++ b/src/domain/application/use-cases/register-delivery-person.ts
@@ -1,7 +1,8 @@
-import { Either, right } from '@/core/either'
+import { Either, left, right } from '@/core/either'
 import { DeliveryPerson } from '@/domain/enterprise/entities/delivery-person'
 import { DeliveryPeopleRepository } from '../repositories/delivery-people.repository'
 import { Injectable } from '@nestjs/common'
+import { DeliveryPersonAlreadyExistsError } from './errors/delivery-person-already-exists.error'
 
 interface RegisterDeliveryPersonUseCaseRequest {
   name: string
@@ -11,7 +12,7 @@ interface RegisterDeliveryPersonUseCaseRequest {
 }
 
 type RegisterDeliveryPersonUseCaseResponse = Either<
-  null,
+  DeliveryPersonAlreadyExistsError,
   {
     deliveryPerson: DeliveryPerson
   }
@@ -33,6 +34,13 @@ export class RegisterDeliveryPersonUseCase {
       password,
       admin,
     })
+
+    const deliveryPersonOnDatabase =
+      await this.deliveryPeopleRepository.findByCpf(cpf)
+
+    if (deliveryPersonOnDatabase) {
+      return left(new DeliveryPersonAlreadyExistsError())
+    }
 
     await this.deliveryPeopleRepository.create(deliveryPerson)
 

--- a/src/infra/database/mongoose/repositories/mongoose-delivery-people.repository.ts
+++ b/src/infra/database/mongoose/repositories/mongoose-delivery-people.repository.ts
@@ -3,6 +3,7 @@ import { DeliveryPerson } from '@/domain/enterprise/entities/delivery-person'
 import { Injectable } from '@nestjs/common'
 import { MongooseDeliveryPersonMapper } from '../mappers/mongoose-delivery-person.mapper'
 import { MongooseService } from '../mongoose.service'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 
 @Injectable()
 export class MongooseDeliveryPeopleRepository
@@ -14,5 +15,19 @@ export class MongooseDeliveryPeopleRepository
     const data = MongooseDeliveryPersonMapper.toMongoose(deliveryPerson)
 
     await this.mongoose.user.create(data)
+  }
+
+  async findByCpf(cpf: string) {
+    const deliveryPerson = await this.mongoose.user.findOne({ cpf })
+
+    return DeliveryPerson.create(
+      {
+        name: deliveryPerson.name,
+        cpf: deliveryPerson.cpf,
+        admin: deliveryPerson.admin,
+        password: deliveryPerson.password,
+      },
+      new UniqueEntityID(deliveryPerson._id),
+    )
   }
 }

--- a/src/infra/database/mongoose/repositories/mongoose-delivery-people.repository.ts
+++ b/src/infra/database/mongoose/repositories/mongoose-delivery-people.repository.ts
@@ -20,14 +20,16 @@ export class MongooseDeliveryPeopleRepository
   async findByCpf(cpf: string) {
     const deliveryPerson = await this.mongoose.user.findOne({ cpf })
 
-    return DeliveryPerson.create(
-      {
-        name: deliveryPerson.name,
-        cpf: deliveryPerson.cpf,
-        admin: deliveryPerson.admin,
-        password: deliveryPerson.password,
-      },
-      new UniqueEntityID(deliveryPerson._id),
-    )
+    return deliveryPerson
+      ? DeliveryPerson.create(
+          {
+            name: deliveryPerson.name,
+            cpf: deliveryPerson.cpf,
+            admin: deliveryPerson.admin,
+            password: deliveryPerson.password,
+          },
+          new UniqueEntityID(deliveryPerson._id),
+        )
+      : null
   }
 }

--- a/test/in-memory-repositories/delivery-people.repository.ts
+++ b/test/in-memory-repositories/delivery-people.repository.ts
@@ -9,4 +9,8 @@ export class InMemoryDeliveryPeopleRepository
   async create(deliveryPerson: DeliveryPerson): Promise<void> {
     this.items.push(deliveryPerson)
   }
+
+  async findByCpf(cpf: string): Promise<DeliveryPerson | null> {
+    return this.items.filter((item) => item.cpf === cpf)[0]
+  }
 }


### PR DESCRIPTION
### 🛠 What was done?
- Added `findByCpf` method to delivery people repositories.
- Implemented error handling to prevent duplicate CPF registration when creating a new delivery person.
- Updated tests to cover the new validation logic.

### 🐛 Why?
Previously, the application allowed registering a delivery person with an already existing CPF, leading to data inconsistency.

### ✅ How to test?
1. Try creating a new delivery person with an already registered CPF.
2. The API should return an appropriate error response.
3. Run tests with `npm test` (or your test command) to ensure all test cases pass.
